### PR TITLE
Add token override ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,18 @@ This contract:
 
 ## Configuration Values
 
+### Kovan
+LINK 0xa36085F69e2889c224210F603D836748e7dC0088
+Oracle 0x2f90A6D021db21e1B2A077c5a37B3C7E75D15b7e
+JobID 29fa9aa13bf1468788b7cc4a500a45b8
+
 ### Rinkeby
-oracle = 0x7AFe1118Ea78C1eae84ca8feE5C65Bc76CcF879e;
-jobId = '6d1bfe27e7034b1d87b5270556b17277';
+LINK 0x01be23585060835e02b77ef475b0cc51aa1e0709
+Oracle 0x7AFe1118Ea78C1eae84ca8feE5C65Bc76CcF879e
+JobID 6d1bfe27e7034b1d87b5270556b17277
 
 ### Mainnet
 NOTE: for the node provider and job id you can choose from a list of various providers from https://market.link/
-oracle = 0x240BaE5A27233Fd3aC5440B5a598467725F7D1cd;
-jobId = '1bc4f827ff5942eaaa7540b7dd1e20b9';
+LINK 0x514910771AF9Ca656af840dff83E8264EcF986CA
+Oracle 0x240BaE5A27233Fd3aC5440B5a598467725F7D1cd
+JobID 1bc4f827ff5942eaaa7540b7dd1e20b9

--- a/contracts/mocks/MockCirculatingMarketCapOracle.sol
+++ b/contracts/mocks/MockCirculatingMarketCapOracle.sol
@@ -18,22 +18,11 @@ contract MockCirculatingMarketCapOracle is CirculatingMarketCapOracle {
   {}
 
   function requestCoinGeckoData(address _token) internal override returns (bytes32 requestId) {
-    return keccak256(abi.encodePacked(_token));
+    (string memory url, string memory key) = getCoingeckoMarketCapUrlAndKey(_token);
+    return keccak256(abi.encodePacked(url, key));
   }
 
   function fulfill(bytes32 _requestId, uint256 _marketCap) external override {
     _fulfill(_requestId, _marketCap);
-  }
-
-  function testUrlDerivation() external pure {
-    address testAddress = 0xf1f1f1F1f1f1F1F1f1F1f1F1F1F1F1f1F1f1f1F1;
-    string memory expectedUrl = "https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=0xf1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1&vs_currencies=eth&include_market_cap=true";
-    string memory realUrl = getCoingeckoMarketCapUrl(
-      addressToString(testAddress)
-    );
-    require(
-      keccak256(abi.encode(expectedUrl)) == keccak256(abi.encode(realUrl)),
-      "Generated URL does not match expected URL"
-    );
   }
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -22,6 +22,10 @@ async function fastForward(seconds) {
   await mineBlock();
 }
 
+const TOKEN_ADDRESS_BASE_URL = "https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=";
+const TOKEN_ID_BASE_URL = "https://api.coingecko.com/api/v3/simple/price?ids=";
+const QUERY_PARAMS = "&vs_currencies=eth&include_market_cap=true";
+
 module.exports = {
   ChainlinkJobId: '6d1bfe27e7034b1d87b5270556b17277',
   OracleAddress: '0x7AFe1118Ea78C1eae84ca8feE5C65Bc76CcF879e',
@@ -35,5 +39,8 @@ module.exports = {
   mineBlock,
   deploy,
   getTransactionTimestamp,
-  fastForward
+  fastForward,
+  TOKEN_ADDRESS_BASE_URL,
+  TOKEN_ID_BASE_URL,
+  QUERY_PARAMS
 }


### PR DESCRIPTION
Add the ability to define a coingecko identifier for a token where the contract address is not the primary asset, e.g. wrapper tokens.